### PR TITLE
Install the XSL module for php5.

### DIFF
--- a/cookbooks/vagrant_main/recipes/default.rb
+++ b/cookbooks/vagrant_main/recipes/default.rb
@@ -108,6 +108,11 @@ package "php5-curl" do
   action :install
 end
 
+# Install php-xsl
+package "php5-xsl" do
+  action :install
+end
+
 # Get eth1 ip
 eth1_ip = node[:network][:interfaces][:eth1][:addresses].select{|key,val| val[:family] == 'inet'}.flatten[0]
 


### PR DESCRIPTION
PR to update the main recipe to enable XSLT functions in PHP by installing the [php5-xsl package](http://packages.ubuntu.com/precise/php5-xsl). I added this as a personal project of mine was using [XSLTProcessor](http://php.net/manual/en/class.xsltprocessor.php) but usage of this extension is common enough that it might be handy to include in a default PHP environment.
