### PR TITLE
Confusing wording in the README regarding docroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Notes
 ### Apache virtual hosts
 
 You can add virtual hosts to apache by adding a file to the `data_bags/sites`
-directory. A docroot will be created automatically in the `public` folder, or 
-you may specify a docroot explicitly by adding a docroot key in the json file.  
+directory. The docroot of the new virtual host will be a directory within the
+`public/` folder matching the `host` you specified. Alternately you may specify
+a docroot explicitly by adding a `docroot` key in the json file.
 
 ### MySQL
 


### PR DESCRIPTION
Maybe I was just being dumb, but I got really confused by the wording in the [Apache Virtual Hosts](https://github.com/r8/vagrant-lamp#apache-virtual-hosts) section of the readme. I thought it was implying that it would actually create an empty directory for me in `public/` after I created a `.json` file.

I spent a fair amount of time trying to debug why the directory was not being created for me.
