### PR TITLE
What's the best way to set default php.ini directives?

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,5 +47,20 @@ Vagrant.configure("2") do |config|
     chef.add_recipe "vagrant_main::drupal"
     chef.add_recipe "vagrant_main::magento"
     chef.add_recipe "vagrant_main::nodejs"
+
+    chef.json = {
+      "php" => {
+        "directives" => {
+          # Set custom PHP directives
+          "display_errors" => "On",
+          "display_startup_errors" => "On",
+          "error_reporting" => "-1",
+          "log_errors" => "On"
+        }
+      },
+      "mysql" => {
+        "server_root_password" => "vagrant"
+      }
+    }
   end
 end

--- a/cookbooks/apache2/recipes/mod_php5.rb
+++ b/cookbooks/apache2/recipes/mod_php5.rb
@@ -76,3 +76,13 @@ apache_module "php5" do
     filename "libphp5.so"
   end
 end
+
+# Tweak to allow customization of the apache php.ini courtesy of
+# @chipadeedoodah in #vagrant irc
+template '/etc/php5/apache2/php.ini' do
+  source 'php.ini.erb'
+  cookbook 'php'
+  owner 'root'
+  group 'root'
+  mode '0644'
+end


### PR DESCRIPTION
I would like to turn on `display_errors` and `display_startup_errros` and a few other debugging-friendly directives.

```
display_errors = On
display_startup_errors = On
error_reporting = -1
log_errors = On
```

What's the proper way to add these?
