### PR TITLE
Change failure message when sites data bag fails to load

### DIFF
--- a/cookbooks/vagrant_main/recipes/default.rb
+++ b/cookbooks/vagrant_main/recipes/default.rb
@@ -37,7 +37,7 @@ sites = []
 begin
   sites = data_bag("sites")
 rescue
-  puts "Sites data bag is empty"
+  puts "Unable to load sites data bag."
 end
 
 # Configure sites


### PR DESCRIPTION
The current message assumes the reason the sites were not loaded is because there are none. However syntax errors can also cause the data not to load. The error message should be more specific.
