### PR TITLE
Forced rake 0.8.7 to be installed in order to work with ruby 1.8.7

### DIFF
--- a/cookbooks/vagrant_main/recipes/default.rb
+++ b/cookbooks/vagrant_main/recipes/default.rb
@@ -21,8 +21,12 @@ include_recipe "php-box"
 end
 
 # Install ruby gems
-%w{ rdoc rake mailcatcher }.each do |a_gem|
+%w{ rdoc mailcatcher }.each do |a_gem|
   gem_package a_gem
+end
+
+gem_package "rake" do
+  version "0.8.7"
 end
 
 # Generate selfsigned ssl


### PR DESCRIPTION
This is a fix for https://github.com/r8/vagrant-lamp/issues/86
