### PR TITLE
Fixed Downloading of magento tools by adding -L to curl command

### DIFF
--- a/cookbooks/magento-toolbox/recipes/modgit.rb
+++ b/cookbooks/magento-toolbox/recipes/modgit.rb
@@ -11,7 +11,7 @@ package "curl" do
   action :upgrade
 end
 
-command = "curl -o modgit https://raw.github.com/jreinke/modgit/master/modgit && chmod +x ./modgit"
+command = "curl -L -o modgit https://raw.github.com/jreinke/modgit/master/modgit && chmod +x ./modgit"
 
 bash "download_modgit" do
   cwd "#{Chef::Config[:file_cache_path]}"

--- a/cookbooks/magento-toolbox/recipes/modman.rb
+++ b/cookbooks/magento-toolbox/recipes/modman.rb
@@ -11,7 +11,7 @@ package "curl" do
   action :upgrade
 end
 
-command = "curl -o modman https://raw.github.com/colinmollenhour/modman/master/modman && chmod +x ./modman"
+command = "curl -L -o modman https://raw.github.com/colinmollenhour/modman/master/modman && chmod +x ./modman"
 
 bash "download_modman" do
   cwd "#{Chef::Config[:file_cache_path]}"

--- a/cookbooks/magento-toolbox/recipes/n98-magerun.rb
+++ b/cookbooks/magento-toolbox/recipes/n98-magerun.rb
@@ -13,7 +13,7 @@ package "curl" do
   action :upgrade
 end
 
-command = "curl -o n98-magerun.phar https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar && chmod +x ./n98-magerun.phar"
+command = "curl -L -o n98-magerun.phar https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar && chmod +x ./n98-magerun.phar"
 
 bash "download_n98-magerun" do
   cwd "#{Chef::Config[:file_cache_path]}"


### PR DESCRIPTION
The Magento-toolbox recipes failed to download some ressources from raw.github.com e.g.
https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar
By adding the -L option to the curl command, we make sure to follow redirects and fix the following error(s)
## Vagrant log:
# 
# Error executing action `run` on resource 'bash[download_n98-magerun]'
## Mixlib::ShellOut::ShellCommandFailed

Expected process to exit with [0], but received '1'
---- Begin output of "bash"  "/tmp/chef-script20140619-1850-kcrjkx-0" ----
STDOUT:
STDERR: % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
chmod: cannot access `./n98-magerun.phar': No such file or directory
---- End output of "bash"  "/tmp/chef-script20140619-1850-kcrjkx-
