### PR TITLE
Make MySQL storage persistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Download and install [VirtualBox](http://www.virtualbox.org/)
 
 Download and install [vagrant](http://vagrantup.com/)
 
+Optionally, install the [vagrant persistent storage plugin](https://github.com/kusnier/vagrant-persistent-storage)
+
+    $ vagrant plugin install vagrant-persistent-storage
+
 Download a vagrant box (name of the box is supposed to be precise32)
 
     $ vagrant box add precise32 http://files.vagrantup.com/precise32.box
@@ -27,7 +31,8 @@ What's inside:
 Installed software:
 
 * Apache
-* MySQL
+* MySQL (will use persistent storage if you installed the plugin above, so you
+  can safely destroy the box)
 * php
 * phpMyAdmin
 * Xdebug with Webgrind

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,17 @@ Vagrant.configure("2") do |config|
   # Set share folder permissions to 777 so that apache can write files
   config.vm.synced_folder ".", "/vagrant", mount_options: ['dmode=777','fmode=666']
 
+  # Create a persistent storage for MySQL. See https://github.com/kusnier/vagrant-persistent-storage
+  if defined? VagrantPlugins::PersistentStorage
+    config.persistent_storage.enabled = true
+    config.persistent_storage.location = "vagrant-mysql.vdi"
+    config.persistent_storage.size = 5000
+    config.persistent_storage.mountname = 'mysql'
+    config.persistent_storage.filesystem = 'ext4'
+    config.persistent_storage.mountpoint = '/var/lib/mysql'
+    config.persistent_storage.volgroupname = 'vagrant'
+  end
+
   # Provider-specific configuration so you can fine-tune VirtualBox for Vagrant.
   # These expose provider-specific options.
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
This pull request adds persistent storage for MySQL using the [vagrant persistent storage plugin](https://github.com/kusnier/vagrant-persistent-storage). (The changes to the Vagrantfile are thus that the plugin is not required, things will continue to function like they did before when the plugin is not installed).
