### PR TITLE
fix missing ´name´attribute

### DIFF
--- a/cookbooks/drush/metadata.rb
+++ b/cookbooks/drush/metadata.rb
@@ -1,3 +1,4 @@
+name             "drush"
 maintainer       "Mark Sonnabaum"
 maintainer_email "mark.sonnabaum@acquia.com"
 license          "Apache 2.0"

--- a/cookbooks/npm/metadata.rb
+++ b/cookbooks/npm/metadata.rb
@@ -18,6 +18,7 @@
 # limitations under the License.
 #
 
+name             "npm"
 maintainer       "Sergey Balbeko"
 maintainer_email "sergey@balbeko.com"
 license          "Apache License, Version 2.0"

--- a/cookbooks/vagrant_main/metadata.rb
+++ b/cookbooks/vagrant_main/metadata.rb
@@ -1,3 +1,4 @@
+name             "vagrant_main"
 maintainer       "YOUR_COMPANY_NAME"
 maintainer_email "YOUR_EMAIL"
 license          "All rights reserved"


### PR DESCRIPTION
Fix errors like :
ERROR: Cookbook loaded at path(s) [/tmp/vagrant-chef-4/chef-solo-1/cookbooks/drush] has invalid metadata: The `name' attribute is required in cookbook metadata

<!---
@huboard:{"order":5.5,"milestone_order":109,"custom_state":""}
-->
